### PR TITLE
Add option not to load librairies at field render.

### DIFF
--- a/GeoFormAlchemy/README.rst
+++ b/GeoFormAlchemy/README.rst
@@ -113,6 +113,15 @@ called on the field ``the_geom`` of the custom ``FieldSet`` changes the backgrou
     If ``show_map`` is set to ``False``, the geometry will be displayed as WKT string 
     inside a text input field.
 
+``insert_libs`` (default: ``True``)
+    If ``insert_libs`` is set to ``False``, OpenLayers, GeoFormAlchemy JS and
+    stylesheet are not loaded. You have to do it yourself.
+
+``run_js`` (default: ``True``)
+    If ``run_js`` is set to ``False``, The call to
+    ``geoformalchemy.init_map()`` is not done. You can call it manuallay with
+    ``fs.render_fields['the_geom'].renderer.render_runjs()``
+
 Template files
 ~~~~~~~~~~~~~~~
 

--- a/GeoFormAlchemy/geoformalchemy/base.py
+++ b/GeoFormAlchemy/geoformalchemy/base.py
@@ -3,7 +3,7 @@ from formalchemy.forms import FieldSet
 from formalchemy.tables import Grid
 from formalchemy import helpers as h, config
 
-from geoalchemy.geometry import (Point, Curve, LineString, 
+from geoalchemy.geometry import (Point, Curve, LineString,
     Polygon, MultiPoint, MultiLineString, MultiPolygon)
 from geoalchemy.base import PersistentSpatialElement, WKTSpatialElement
 from geoalchemy.functions import functions
@@ -15,65 +15,65 @@ import os
 
 class GeometryFieldRenderer(FieldRenderer):
     """An extension for FormAlchemy that renders GeoAlchemy's geometry type
-    
+
     To enable this extension, it has to be registered as 'default_renderer'::
-        
+
         from geoformalchemy.base import GeometryFieldRenderer
         from geoalchemy import geometry
         from formalchemy.forms import FieldSet
         FieldSet.default_renderers[geometry.Geometry] = GeometryFieldRenderer
-        
-        
+
+
     The rendering of a specific field can be customized without having to change
     the template files. If an option is not set, the default value specified in
     the template file 'map.mako' will be used::
-        
+
         Place = FieldSet(model.places.Place)
         Place.the_geom.set(options=[
             ('map_srid', 900913),
             ('base_layer', 'new OpenLayers.Layer.OSM("OSM")')])
-            
-            
+
+
     Following options can be used::
-        
+
         default_lat
         default_lon
             If the geometry is ''None'' or when creating a new geometry, the map
             is centered at (default_lon, default_lat).
-        
+
         zoom
             The zoom-level on start-up.
-        
+
         map_width
         map_height
             The size of the DIV container in which the map is displayed.
-            
+
         base_layer
             The OpenLayers layer which will be used as background map, for example::
-                ('base_layer', 'new OpenLayers.Layer.OSM("OSM")') 
-        
+                ('base_layer', 'new OpenLayers.Layer.OSM("OSM")')
+
         map_srid
             If the map uses a different CRS than the geometries, the geometries will be
             reprojected to this CRS.
-            
+
         openlayers_lib
             The path to the OpenLayers JavaScript library, for example::
-                ('openlayers_lib', 'http://openlayers.org/api/OpenLayers.js') 
-            
+                ('openlayers_lib', 'http://openlayers.org/api/OpenLayers.js')
+
         show_map (default: True)
-            If ``show_map`` is set to ``False``, the geometry will be displayed as WKT string 
+            If ``show_map`` is set to ``False``, the geometry will be displayed as WKT string
             inside a text input field.
-            
+
     """
-    
+
     def __init__(self, field):
         self.__templates = None
-        
+
         FieldRenderer.__init__(self, field)
-    
+
     def render(self, **kwargs):
         return self.__render_map(False)
-    
+
     def render_readonly(self, **kwargs):
         if isinstance(self.field.parent, FieldSet):
             # if rendering for a FieldSet (when a single entry is displayed),
@@ -87,25 +87,25 @@ class GeometryFieldRenderer(FieldRenderer):
             else:
                 # geometry type
                 return self.field.type.__class__.name
-        
+
     @deserialize_once
     def deserialize(self):
         """Turns the user input into a GeoAlchemy geometry, which
         can be stored in the database.
         """
         form_value = self.params.getone(self.name)
-        
+
         if form_value is not None and form_value.strip() != '':
             return WKTSpatialElement(
                 form_value,
                 srid=self.__get_options().get('map_srid', self.field.type.srid))
 
         return None
-    
+
     def __render_map(self, read_only):
         options = self.__get_options()
         geometry_type = self.__get_type_information()
-        
+
         if len(self.field.errors) > 0:
             # if re-displaying a form with errors, get the WKT string
             # from the form submission
@@ -113,31 +113,26 @@ class GeometryFieldRenderer(FieldRenderer):
         else:
             # if displaying a new form, try to query the geometry in WKT
             wkt = self.__get_wkt_for_field(options);
-        
+
         if not options.get('show_map', True):
             # if no map should be shown, just display a text field
             if read_only:
                 return h.text_field(self.name, value=wkt, readonly='readonly')
-            else: 
+            else:
                 return h.text_field(self.name, value=wkt)
-        
+
         template_args = {
                         'field_name' : self.name,
-                        'wkt' : wkt,
                         'input_field' : h.hidden_field(self.name, value=wkt),
                         #'input_field' : h.text_field(self.name, value=wkt), # for debug
-                        'read_only' : 'true' if read_only else 'false',
-                        'is_collection' : 'true' if geometry_type['is_collection'] else 'false',
-                        'geometry_type' : geometry_type['geometry_type'] ,
-                        'default_lat' : options.get('default_lat', None),
-                        'default_lon' : options.get('default_lon', None),
-                        'zoom' : options.get('zoom', None),
                         'map_width' : options.get('map_width', None),
                         'map_height' : options.get('map_height', None),
-                        'base_layer' : options.get('base_layer', None),
-                        'openlayers_lib' : options.get('openlayers_lib', None)   
+                        'openlayers_lib' : options.get('openlayers_lib', None),
+                        'insert_libs' : options.get('insert_libs', True),
+                        'run_js' : options.get('run_js', True),
+                        'renderer': self
                     }
-        
+
         try:
             """Try to render the template with the FormAlchemy template engine which assumes that
             the 'map.mako' template file is in the same folder as the other FormAlchemy template files.
@@ -148,23 +143,57 @@ class GeometryFieldRenderer(FieldRenderer):
             map_template = self.get_templates().get_template('map.mako')
             return map_template.render(**template_args)
 
+    def render_runjs(self, read_only=False):
+        options = self.__get_options()
+        geometry_type = self.__get_type_information()
+
+        if len(self.field.errors) > 0:
+            # if re-displaying a form with errors, get the WKT string
+            # from the form submission
+            wkt = self.params.getone(self.name)
+        else:
+            # if displaying a new form, try to query the geometry in WKT
+            wkt = self.__get_wkt_for_field(options);
+
+        template_args = {
+                        'field_name' : self.name,
+                        'wkt' : wkt,
+                        'read_only' : 'true' if read_only else 'false',
+                        'is_collection' : 'true' if geometry_type['is_collection'] else 'false',
+                        'geometry_type' : geometry_type['geometry_type'] ,
+                        'default_lat' : options.get('default_lat', None),
+                        'default_lon' : options.get('default_lon', None),
+                        'zoom' : options.get('zoom', None),
+                        'base_layer' : options.get('base_layer', None),
+                    }
+
+        try:
+            """Try to render the template with the FormAlchemy template engine which assumes that
+            the 'map.mako' template file is in the same folder as the other FormAlchemy template files.
+            This is the case when used inside a Pylons app."""
+            return config.engine.render('run', **template_args)
+        except (TemplateLookupException, AttributeError, ValueError):
+            # otherwise render the default template using an own template engine
+            map_template = self.get_templates().get_template('run.mako')
+            return map_template.render(**template_args)
+
     def __get_wkt_for_field(self, options):
         """Returns the WKT string for the value of a field by making
         a database query.
-        
-        If necessary the geometry is reprojected.  
+
+        If necessary the geometry is reprojected.
         """
-        if self.raw_value is not None and isinstance(self.raw_value, PersistentSpatialElement): 
+        if self.raw_value is not None and isinstance(self.raw_value, PersistentSpatialElement):
             geom_srid = self.field.type.srid
             map_srid = options.get('map_srid', geom_srid)
-            
+
             if geom_srid != map_srid:
                 # if the map uses a different CRS we have to ask the database
                 # to reproject the geometry
                 query = functions.wkt(functions.transform(self.raw_value, map_srid))
             else:
                 query = self.raw_value.wkt
-            
+
             session = self.field.parent.session
             return session.scalar(query)
         else:
@@ -173,13 +202,13 @@ class GeometryFieldRenderer(FieldRenderer):
     def __get_type_information(self):
         """This method maps GeoAlchemy geometry types to the
         equivalent OpenLayers geometries.
-        
+
         A dictionary is returned with two keys:
             is_collection: True for Multi* geometry types
             geometry_type: The OpenLayers geometry type
         """
         geom_type = self.field.type
-        
+
         if isinstance(geom_type, (Point, MultiPoint)):
             is_collection = isinstance(geom_type, MultiPoint)
             geometry_type = 'Point'
@@ -192,22 +221,22 @@ class GeometryFieldRenderer(FieldRenderer):
         else:
             is_collection = True
             geometry_type = 'Collection'
-        
+
         return {
                 'is_collection' : is_collection,
                 'geometry_type' : geometry_type
                 }
-    
+
     def __get_options(self):
         """Turns the options list, a list of tuples e.g. [('..', '..'), ('..', '..')],
         into a real dictionary.
         """
         options_list = self.field.render_opts.get('options', [])
         return dict(options_list)
-    
+
     def get_templates(self):
         if self.__templates == None:
             dirname = os.path.join(os.path.dirname(__file__), 'pylons', 'project', '+package+', 'templates', 'forms')
             self.__templates = TemplateLookup([dirname], input_encoding='utf-8', output_encoding='utf-8')
-        
+
         return self.__templates

--- a/GeoFormAlchemy/geoformalchemy/pylons/project/+package+/templates/forms/map.mako
+++ b/GeoFormAlchemy/geoformalchemy/pylons/project/+package+/templates/forms/map.mako
@@ -3,68 +3,58 @@
 # no field options were set, e.g. with:
 #
 # Place = FieldSet(model.places.Place)
-# Place.the_geom.set(options=[('zoom', 12), ..]) 
+# Place.the_geom.set(options=[('zoom', 12), ..])
 
 options = {}
-options['default_lon'] = 10
-options['default_lat'] = 45
-options['zoom'] = 4
 options['map_width'] = 512
 options['map_height'] = 256
-options['base_layer'] = 'new OpenLayers.Layer.WMS("WMS", "http://labs.metacarta.com/wms/vmap0", {layers: "basic"})'
 options['openlayers_lib'] = 'http://openlayers.org/dev/OpenLayers.js'
 
 %>
 
+% if insert_libs:
 <script src="${openlayers_lib or options['openlayers_lib']}"></script>
-
 <style>
-.formmap_${field_name} {
-    width: ${map_width or options['map_width']}px;
-    height: ${map_height or options['map_height']}px;
+.formmap {
     border: 1px solid #ccc;
-## temporarily fix issue addressed in openlayers ticket #1635 :
-## http://trac.osgeo.org/openlayers/ticket/1635#comment:7
-## (to be remove when this ticket is closed)
+    ## temporarily fix issue addressed in openlayers ticket #1635 :
+    ## http://trac.osgeo.org/openlayers/ticket/1635#comment:7
+    ## (to be remove when this ticket is closed)
     position: relative;
     z-index: 0;
 }
 
 .olControlAttribution {
-    bottom: 2px; 
+    bottom: 2px;
 }
 
-.olControlEditingToolbar .olControlModifyFeatureItemActive { 
+.olControlEditingToolbar .olControlModifyFeatureItemActive {
     background-image: url("/adminapp/images/select_feature_on.png");
 }
-.olControlEditingToolbar .olControlModifyFeatureItemInactive { 
+.olControlEditingToolbar .olControlModifyFeatureItemInactive {
     background-image: url("/adminapp/images/select_feature_off.png");
 }
 
-.olControlEditingToolbar .olControlDeleteFeatureItemActive { 
+.olControlEditingToolbar .olControlDeleteFeatureItemActive {
     background-image: url("/adminapp/images/remove_feature_on.png");
 }
-.olControlEditingToolbar .olControlDeleteFeatureItemInactive { 
+.olControlEditingToolbar .olControlDeleteFeatureItemInactive {
     background-image: url("/adminapp/images/remove_feature_off.png");
 }
 </style>
+<script type="text/javascript">
+    <%include file="map_js.mako" />
+</script>
+% endif
 
 <div>
     ${input_field}
-    <div id="map_${field_name}" class="formmap_${field_name}"></div>
-    <script type="text/javascript">
-        <%include file="map_js.mako" />
-        geoformalchemy.init_map(
-                '${field_name}',
-                ${read_only},
-                ${is_collection},
-                '${geometry_type}',
-                ${default_lon or options['default_lon']},
-                ${default_lat or options['default_lat']},
-                ${zoom or options['zoom']},
-                ${base_layer or options['base_layer'] | n},
-                '${wkt}'
-        );
+    <div id="map_${field_name}" class="formmap"
+        style="width: ${map_width or options['map_width']}px; height: ${map_height or options['map_height']}px;"></div>
+    % if run_js:
+    <script>
+    ${renderer.render_runjs()}
     </script>
+    % endif
     <br />
 </div>

--- a/GeoFormAlchemy/geoformalchemy/pylons/project/+package+/templates/forms/run.mako
+++ b/GeoFormAlchemy/geoformalchemy/pylons/project/+package+/templates/forms/run.mako
@@ -1,0 +1,26 @@
+<%
+# default configuration options that will be used when
+# no field options were set, e.g. with:
+#
+# Place = FieldSet(model.places.Place)
+# Place.the_geom.set(options=[('zoom', 12), ..])
+
+options = {}
+options['default_lon'] = 10
+options['default_lat'] = 45
+options['zoom'] = 4
+options['base_layer'] = 'new OpenLayers.Layer.WMS("WMS", "http://labs.metacarta.com/wms/vmap0", {layers: "basic"})'
+
+%>
+geoformalchemy.init_map(
+    '${field_name}',
+    ${read_only},
+    ${is_collection},
+    '${geometry_type}',
+    ${default_lon or options['default_lon']},
+    ${default_lat or options['default_lat']},
+    ${zoom or options['zoom']},
+    ${base_layer or options['base_layer'] | n},
+    '${wkt}'
+);
+

--- a/GeoFormAlchemy/geoformalchemy/tests/test_geometryfieldrenderer.py
+++ b/GeoFormAlchemy/geoformalchemy/tests/test_geometryfieldrenderer.py
@@ -22,22 +22,22 @@ Base = declarative_base(metadata=metadata)
 
 class Spot(Base):
     __tablename__ = 'spots'
-    
+
     id = Column(types.Integer, primary_key=True)
     name = Column(types.String, nullable=False)
     the_geom = GeometryColumn(Point(dimension=2, srid=4326))
 
 class FakeSession(Session):
-    
+
     def __init__(self):
         pass
-    
+
     def scalar(self, *args, **kwargs):
         self.scalar_args = args
         self.scalar_kwargs = kwargs
-        
+
         return 'geometry'
-  
+
     def add(self, instance):
         self.add_instance = instance
 
@@ -48,35 +48,35 @@ class TestGeometryFieldRenderer(unittest.TestCase):
     def test_render(self):
         session = FakeSession()
         spot_fieldset = FieldSet(Spot, session=session)
-        
+
         spot = Spot()
         spot.id = 1
         spot.the_geom = PersistentSpatialElement(PersistentSpatialElement(WKBSpatialElement('010')));
-        
+
         spot_fieldset = spot_fieldset.bind(spot)
-        
+
         form = spot_fieldset.render()
-        
+
         ok_("geoformalchemy.init_map(" in form, 'Template was not rendered')
         ok_("'Point'," in form, 'OpenLayers geometry was not mapped correctly ')
         ok_("false," in form, 'Geometry should not be a collection')
         ok_(isinstance(session.scalar_args[0], functions.wkt), 'The geometry was not queried as WKT');
-        
+
     def test_render_reproject(self):
         session = FakeSession()
         spot_fieldset = FieldSet(Spot, session=session)
         spot_fieldset.the_geom.set(options=[('map_srid', 900913)])
-        
+
         spot = Spot()
         spot.id = 1
         spot.the_geom = PersistentSpatialElement(PersistentSpatialElement(WKBSpatialElement('010')));
-        
+
         spot_fieldset = spot_fieldset.bind(spot)
-        
+
         spot_fieldset.render()
         ok_(isinstance(session.scalar_args[0], functions.wkt), 'The geometry was not queried as WKT');
         ok_(isinstance(session.scalar_args[0].arguments[0], functions.transform), 'The geometry was not reprojected');
-        
+
     def test_render_options(self):
         spot_fieldset = FieldSet(Spot)
         spot_fieldset.the_geom.set(options=[
@@ -87,41 +87,55 @@ class TestGeometryFieldRenderer(unittest.TestCase):
                         ('map_height', 5),
                         ('base_layer', 'new OpenLayers.Layer.DummyLayer("OSM")'),
                         ('openlayers_lib', '/js/OpenLayers.js')])
-        
+
         form = spot_fieldset.render()
-        
+
         ok_('1,\n            2,\n            3,            \'Point\',            new OpenLayers.Layer.DummyLayer("OSM"),', form)
         ok_('<script src="/js/OpenLayers.js"></script>' in form)
-        
+        ok_('init_map(' in form)
+
+    def test_render_additional_options(self):
+        spot_fieldset = FieldSet(Spot)
+        spot_fieldset.the_geom.set(options=[
+                        ('default_lat', 1),
+                        ('default_lon', 2),
+                        ('zoom', 3),
+                        ('map_width', 4),
+                        ('map_height', 5),
+                        ('base_layer', 'new OpenLayers.Layer.DummyLayer("OSM")'),
+                        ('run_js', False),
+                        ('insert_libs', False)
+                        ])
+
+        form = spot_fieldset.render()
+
+        ok_('<script src="/js/OpenLayers.js"></script>' not in form)
+        ok_('init_map(' not in form)
+
     def test_render_validate(self):
-        params = {'Spot--the_geom': 'Point(0 1)', 'Spot--name': ''}
-        
+        params = {'Spot--the_geom': 'Point(0 1)'}
+
         spot_fieldset = FieldSet(Spot, data = params)
-        
+
         spot_fieldset.validate()
         form = spot_fieldset.render()
         ok_("Point(0 1)'" in form, 'submitted value was not re-displayed in case of validation error')
-        
-    def test_deserialize_reproject(self):
+
+    def test_deserialize(self):
         params = {'Spot--the_geom': 'Point(0 1)', 'Spot--name': 'dummy'}
         session = FakeSession()
-        
+
         spot_fieldset = FieldSet(Spot, data = params, session=session)
-        spot_fieldset.the_geom.set(options=[('map_srid', 900913)])
-        
+        spot_fieldset.the_geom.set(options=[('map_srid', 4326)])
+
         spot_fieldset.validate()
         spot_fieldset.sync()
         ok_(isinstance(spot_fieldset.model.the_geom, WKTSpatialElement), 'Geometry was not assigned to model')
-        eq_(spot_fieldset.model.the_geom.desc, 'geometry', 'The geometry was not reprojected for the insertion into the db')
-        
-        spot_fieldset.render()
-        ok_(isinstance(session.scalar_args[0], functions.wkt), 'The geometry was not queried as WKT')
-        ok_(isinstance(session.scalar_args[0].arguments[0], functions.transform), 'The geometry was not reprojected')
-        
+        eq_(str(spot_fieldset.model.the_geom), 'Point(0 1)', 'wkt is wrong')
+
         params = {'Spot--the_geom': ' ', 'Spot--name': ''}
         spot_fieldset = FieldSet(Spot, data = params, session=session)
         spot_fieldset.validate()
         spot_fieldset.sync()
         ok_(spot_fieldset.model.the_geom is None, 'Geometry is not set to None for empty strings')
-        
-        
+


### PR DESCRIPTION
That allows to load OpenLayers when we want, call map widget only on domready.

Also add a renderer method to exec js on its own (and disable it at field render, with an option).

Fixes tests that were previously broken.
