### PR TITLE
constructor of pyramid_formalchemy.utils.TemplateEngine has a "renderer" 

### DIFF
--- a/GeoFormAlchemy/geoformalchemy/base.py
+++ b/GeoFormAlchemy/geoformalchemy/base.py
@@ -130,7 +130,10 @@ class GeometryFieldRenderer(FieldRenderer):
                         'openlayers_lib' : options.get('openlayers_lib', None),
                         'insert_libs' : options.get('insert_libs', True),
                         'run_js' : options.get('run_js', True),
-                        'renderer': self
+                        # we use _renderer as renderer is a named argument
+                        # of pyramid_formalchemy.utils.TemplateEngine:__init__
+                        # This is fragile!
+                        '_renderer': self,
                     }
 
         try:

--- a/GeoFormAlchemy/geoformalchemy/pylons/project/+package+/templates/forms/map.mako
+++ b/GeoFormAlchemy/geoformalchemy/pylons/project/+package+/templates/forms/map.mako
@@ -53,7 +53,7 @@ options['openlayers_lib'] = 'http://openlayers.org/dev/OpenLayers.js'
         style="width: ${map_width or options['map_width']}px; height: ${map_height or options['map_height']}px;"></div>
     % if run_js:
     <script>
-    ${renderer.render_runjs()}
+    ${_renderer.render_runjs()}
     </script>
     % endif
     <br />


### PR DESCRIPTION
constructor of pyramid_formalchemy.utils.TemplateEngine has a "renderer" positional argument, we need to renamed our own "renderer" argument to avoid the collision
